### PR TITLE
Add GUID as LogID for referencing log relation

### DIFF
--- a/.azuredevops/workflows/azure-pipelines.yml
+++ b/.azuredevops/workflows/azure-pipelines.yml
@@ -10,6 +10,14 @@ trigger:
     exclude:
       - README.md
 
+pr:
+  branches:
+    include:
+      - feature/*
+  paths:
+    exclude:
+      - README.md
+
 variables:
   PesterVersion: '5.2.2'
 

--- a/.github/workflows/logistic-ci.yml
+++ b/.github/workflows/logistic-ci.yml
@@ -4,6 +4,8 @@ name: logistic-ci
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'src/**'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.0] - 2021-08-11
+
+### Added
+
+- GUID as `LogID` for easier tracing of logentries which belong together
+- `LogID` and `Type` filter for `Get-LogisticLog`
+- Optional Parameter `LogID` for `ConvertTo-Logentry`
+
+### Fixed
+
+- `Get-LogisticLog` for PowerShell version 5 missing parameter `-Depth` for `ConvertFrom-Json`
+
 ## [v0.0.3] - 2021-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ C:\> $Logistic.CloseStreamWriter()
 C:\> $Data = Get-LogisticLog -Path .\logistic.log
 C:\> $Data
 
+LogID             : 6e4c7a5f-03bc-4e9e-bc90-a466a4c4e4ff
 Timestamp         : 2021-07-31 21:47:02.737
 Callstack         : Runspace
 Data              : Testentry
 Type              : Warning
 TimestampDatetime : 31.07.2021 21:47:02
 
+LogID             : 6e4c7a5f-03bc-4e9e-bc90-a466a4c4e4ff
 Timestamp         : 2021-07-31 21:47:46.401
 Callstack         : Runspace
 Data              : @{Testobject=123; Testobject2=String}

--- a/docs/ConvertTo-Logentry.md
+++ b/docs/ConvertTo-Logentry.md
@@ -8,45 +8,42 @@ schema: 2.0.0
 # ConvertTo-Logentry
 
 ## SYNOPSIS
-
-Converts an InputObject (f.e. \[string\], \[PSCustomObject\]) into a log string.
+Converts an InputObject (f.e.
+\[string\], \[PSCustomObject\]) into a log string.
 
 ## SYNTAX
 
-```powershell
-ConvertTo-Logentry [-InputObject] <PSObject> [-Format <String>] [-Type <String>] [<CommonParameters>]
+```
+ConvertTo-Logentry [-InputObject] <PSObject> [-Format <String>] [-Type <String>] [-LogID <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
-Converts an InputObject (f.e. \[string\], \[PSCustomObject\]) into a log string.
+Converts an InputObject (f.e.
+\[string\], \[PSCustomObject\]) into a log string.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
-
-```powershell
+```
 ConvertTo-Logentry -InputObject "Teststring" -Format JSON
 {"Timestamp":"2021-08-01 23:09:11.179","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 ```
 
 ### EXAMPLE 2
-
-```powershell
+```
 ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON
 {"Timestamp":"2021-08-01 23:09:58.362","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
 ```
 
 ### EXAMPLE 3
-
-```powershell
+```
 ConvertTo-Logentry -InputObject "Teststring" -Format SCCM
 <![LOG[Teststring]LOG]!><time="23:10:55.309843" date="2021-08-01" component="Runspace" context="" type="1" thread="" file="Runspace">
 ```
 
 ### EXAMPLE 4
-
-```powershell
+```
 ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format SCCM
 <![LOG[@{Testobject=Data}]LOG]!><time="23:11:19.298018" date="2021-08-01" component="Runspace" context="" type="1" thread="" file="Runspace">
 ```
@@ -54,7 +51,6 @@ ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format
 ## PARAMETERS
 
 ### -InputObject
-
 Defines the main log information data.
 Can be \[string\] or complex formats like \[PSCustomObject\].
 
@@ -71,7 +67,6 @@ Accept wildcard characters: False
 ```
 
 ### -Format
-
 Defines the log format.
 Can be 'JSON' (default) or 'SCCM'.
 
@@ -88,7 +83,6 @@ Accept wildcard characters: False
 ```
 
 ### -Type
-
 Defines the log type.
 Can be 'Verbose' (default), 'Warning' or 'Error'.
 
@@ -104,18 +98,33 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### -LogID
+{{ Fill LogID Description }}
 
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### [psobject]
-
 ## OUTPUTS
 
 ### [string]
+## NOTES
 
 ## RELATED LINKS
 
-[ConvertTo-Logentry](https://github.com/philmph/Log-istic/blob/main/docs/ConvertTo-Logentry.md)
+[https://github.com/philmph/Log-istic/blob/main/docs/ConvertTo-Logentry.md](https://github.com/philmph/Log-istic/blob/main/docs/ConvertTo-Logentry.md)
+

--- a/docs/ConvertTo-Logentry.md
+++ b/docs/ConvertTo-Logentry.md
@@ -27,14 +27,16 @@ Converts an InputObject (f.e.
 ### EXAMPLE 1
 ```
 ConvertTo-Logentry -InputObject "Teststring" -Format JSON
-{"Timestamp":"2021-08-01 23:09:11.179","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
+{"LogID":"","Timestamp":"2021-08-11 22:30:33.130","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 ```
 
 ### EXAMPLE 2
 ```
-ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON
-{"Timestamp":"2021-08-01 23:09:58.362","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
+ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON -LogID 1234
+{"LogID":1234,"Timestamp":"2021-08-11 22:30:45.221","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
 ```
+
+Using -LogID to add an unique identifier to the logentry.
 
 ### EXAMPLE 3
 ```
@@ -99,7 +101,7 @@ Accept wildcard characters: False
 ```
 
 ### -LogID
-{{ Fill LogID Description }}
+Optional to define a LogID to easier reference log entires later.
 
 ```yaml
 Type: String

--- a/docs/ConvertTo-Logentry.md
+++ b/docs/ConvertTo-Logentry.md
@@ -9,8 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Converts an InputObject (f.e.
-\[string\], \[PSCustomObject\]) into a log string.
+Converts an InputObject (f.e. \[string\], \[PSCustomObject\]) into a log string.
 
 ## SYNTAX
 
@@ -20,8 +19,7 @@ ConvertTo-Logentry [-InputObject] <PSObject> [-Format <String>] [-Type <String>]
 
 ## DESCRIPTION
 
-Converts an InputObject (f.e.
-\[string\], \[PSCustomObject\]) into a log string.
+Converts an InputObject (f.e. \[string\], \[PSCustomObject\]) into a log string.
 
 ## EXAMPLES
 
@@ -117,12 +115,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### [string]
-
-## NOTES
-
-Author: Philipp Maier
-
-Author Git: [GitHub](https://github.com/philmph)
 
 ## RELATED LINKS
 

--- a/docs/Get-LogisticLog.md
+++ b/docs/Get-LogisticLog.md
@@ -24,6 +24,7 @@ Retrieves Logistic logfile data and converts them into PowerShell objects.
 ### EXAMPLE 1
 ```
 Get-LogisticLog -Path .\logistic_json.log
+LogID             : 6200096f-1311-45ba-a67c-22b8710152f2
 Timestamp         : 2021-08-02 09:49:33.007
 Callstack         : Runspace
 Data              : Teststring
@@ -33,6 +34,20 @@ TimestampDatetime : 02.08.2021 09:49:33
 
 ### EXAMPLE 2
 ```
+Get-LogisticLog -Path .\logistic_json.log -LogID '4c7cd194-7059-4f36-822d-3b4722b7cdc8'
+LogID             : 4c7cd194-7059-4f36-822d-3b4722b7cdc8
+Timestamp         : 2021-08-11 22:28:13.961
+Callstack         : Runspace
+Data              : Teststring
+Type              : Error
+TimestampDatetime : 11.08.2021 22:28:13
+```
+
+Using -LogID to filter for '4c7cd194-7059-4f36-822d-3b4722b7cdc8'.
+Alternatively you can filter for -Type.
+
+### EXAMPLE 3
+```
 Get-LogisticLog -Path .\logistic_sccm.log
 Timestamp         : 2021-08-02 09:49:45.330436
 Callstack         : Runspace
@@ -41,10 +56,13 @@ Type              : Verbose
 TimestampDatetime : 02.08.2021 09:49:45
 ```
 
+Note that SCCM doesn't provide the LogID functionality.
+
 ## PARAMETERS
 
 ### -Path
 Defines the path to the logfile.
+Possible values 'All' (default) or a GUID.
 
 ```yaml
 Type: String
@@ -59,7 +77,8 @@ Accept wildcard characters: False
 ```
 
 ### -LogID
-{{ Fill LogID Description }}
+Defines the LogID to filter the log.
+Possible values 'All' (default), 'Verbose', 'Warning' and 'Error'.
 
 ```yaml
 Type: String
@@ -74,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -Type
-{{ Fill Type Description }}
+Defines the Type of entry to filter the log.
 
 ```yaml
 Type: String
@@ -90,6 +109,7 @@ Accept wildcard characters: False
 
 ### -JSONDepth
 Defines the object depth (only relevant for JSON logfiles).
+Only used in major PowerShell version \>= 5.
 
 ```yaml
 Type: Int16

--- a/docs/Get-LogisticLog.md
+++ b/docs/Get-LogisticLog.md
@@ -8,57 +8,42 @@ schema: 2.0.0
 # Get-LogisticLog
 
 ## SYNOPSIS
-
 Retrieves Logistic logfile data and converts them into PowerShell objects.
 
 ## SYNTAX
 
-```powershell
-Get-LogisticLog [-Path] <String> [-JSONDepth <Int16>] [<CommonParameters>]
+```
+Get-LogisticLog [-Path] <String> [-LogID <String>] [-Type <String>] [-JSONDepth <Int16>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
 Retrieves Logistic logfile data and converts them into PowerShell objects.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
-
-```powershell
+```
 Get-LogisticLog -Path .\logistic_json.log
-
 Timestamp         : 2021-08-02 09:49:33.007
 Callstack         : Runspace
 Data              : Teststring
 Type              : Verbose
 TimestampDatetime : 02.08.2021 09:49:33
-
-# Content of logistic_json.log
-Get-Content .\logistic_json.log
-{"Timestamp":"2021-08-02 09:49:33.007","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 ```
 
 ### EXAMPLE 2
-
-```powershell
+```
 Get-LogisticLog -Path .\logistic_sccm.log
-
 Timestamp         : 2021-08-02 09:49:45.330436
 Callstack         : Runspace
 Data              : Teststring
 Type              : Verbose
 TimestampDatetime : 02.08.2021 09:49:45
-
-# Content of logistic_sccm.log
-Get-Content .\logistic_sccm.log
-<![LOG[Teststring]LOG]!><time="09:49:45.330436" date="2021-08-02" component="Runspace" context="" type="1" thread="" file="Runspace">
 ```
 
 ## PARAMETERS
 
 ### -Path
-
 Defines the path to the logfile.
 
 ```yaml
@@ -73,8 +58,37 @@ Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
-### -JSONDepth
+### -LogID
+{{ Fill LogID Description }}
 
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+{{ Fill Type Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: All
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JSONDepth
 Defines the object depth (only relevant for JSON logfiles).
 
 ```yaml
@@ -90,17 +104,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### [string]
-
 ## OUTPUTS
 
 ### [psobject]
+## NOTES
 
 ## RELATED LINKS
 
-[Get-LogisticLog](https://github.com/philmph/Log-istic/blob/main/docs/Get-LogisticLog.md)
+[https://github.com/philmph/Log-istic/blob/main/docs/Get-LogisticLog.md](https://github.com/philmph/Log-istic/blob/main/docs/Get-LogisticLog.md)
+

--- a/docs/Get-LogisticLog.md
+++ b/docs/Get-LogisticLog.md
@@ -35,7 +35,7 @@ Type              : Verbose
 TimestampDatetime : 02.08.2021 09:49:33
 
 # Content of logistic_json.log
-C:\> Get-Content .\logistic_json.log
+Get-Content .\logistic_json.log
 {"Timestamp":"2021-08-02 09:49:33.007","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 ```
 
@@ -51,7 +51,7 @@ Type              : Verbose
 TimestampDatetime : 02.08.2021 09:49:45
 
 # Content of logistic_sccm.log
-C:\> Get-Content .\logistic_sccm.log
+Get-Content .\logistic_sccm.log
 <![LOG[Teststring]LOG]!><time="09:49:45.330436" date="2021-08-02" component="Runspace" context="" type="1" thread="" file="Runspace">
 ```
 
@@ -100,12 +100,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### [psobject]
-
-## NOTES
-
-Author: Philipp Maier
-
-Author Git: [GitHub](https://github.com/philmph)
 
 ## RELATED LINKS
 

--- a/docs/Write-Logentry.md
+++ b/docs/Write-Logentry.md
@@ -24,15 +24,24 @@ Writes log entries into logfile with specific formatting.
 
 ### EXAMPLE 1
 ```
-Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
-WARNING: Teststring
+Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring1'
 ```
 
 ### EXAMPLE 2
 ```
+Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring2' -Type Warning
+WARNING: Teststring
+```
+
+This example outputs a WARNING message to the console on default $WarningPreference
+
+### EXAMPLE 3
+```
 Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
 Write-Logentry : @{Testobject=Data}
 ```
+
+This example outputs an ERROR message to the console on default $ErrorPreference
 
 ## PARAMETERS
 

--- a/docs/Write-Logentry.md
+++ b/docs/Write-Logentry.md
@@ -14,8 +14,7 @@ Writes log entries into logfile with specific formatting.
 ## SYNTAX
 
 ```powershell
-Write-Logentry -LogisticObject <Logistic> [-InputObject] <PSObject> [-Type <String>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+Write-Logentry -LogisticObject <Logistic> [-InputObject] <PSObject> [-Type <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,7 +31,7 @@ Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
 WARNING: Teststring
 
 # Content of logistic.log
-C:\\\> Get-Content .\logistic.log
+Get-Content .\logistic.log
 {"Timestamp":"2021-08-02 20:37:59.548","Callstack":"Runspace","Data":"Teststring","Type":"Warning"}
 ```
 
@@ -44,7 +43,7 @@ Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobj
 Write-Logentry : @{Testobject=Data}
 
 # Content of logistic.log
-C:\\\> Get-Content .\logistic.log
+Get-Content .\logistic.log
 {"Timestamp":"2021-08-02 20:39:57.247","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Error"}
 ```
 
@@ -144,12 +143,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### -
-
-## NOTES
-
-Author: Philipp Maier
-
-Author Git: [GitHub](https://github.com/philmph)
 
 ## RELATED LINKS
 

--- a/docs/Write-Logentry.md
+++ b/docs/Write-Logentry.md
@@ -8,49 +8,35 @@ schema: 2.0.0
 # Write-Logentry
 
 ## SYNOPSIS
-
 Writes log entries into logfile with specific formatting.
 
 ## SYNTAX
 
-```powershell
-Write-Logentry -LogisticObject <Logistic> [-InputObject] <PSObject> [-Type <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+Write-Logentry -LogisticObject <Logistic> [-InputObject] <PSObject> [-Type <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-
 Writes log entries into logfile with specific formatting.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
-
-```powershell
+```
 Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
-
 WARNING: Teststring
-
-# Content of logistic.log
-Get-Content .\logistic.log
-{"Timestamp":"2021-08-02 20:37:59.548","Callstack":"Runspace","Data":"Teststring","Type":"Warning"}
 ```
 
 ### EXAMPLE 2
-
-```powershell
+```
 Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
-
 Write-Logentry : @{Testobject=Data}
-
-# Content of logistic.log
-Get-Content .\logistic.log
-{"Timestamp":"2021-08-02 20:39:57.247","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Error"}
 ```
 
 ## PARAMETERS
 
 ### -LogisticObject
-
 Required as this object provides required log settings.
 
 ```yaml
@@ -66,7 +52,6 @@ Accept wildcard characters: False
 ```
 
 ### -InputObject
-
 Defines the main log information data.
 Can be \[string\] or complex formats like \[PSCustomObject\].
 
@@ -83,7 +68,6 @@ Accept wildcard characters: False
 ```
 
 ### -Type
-
 Defines the log type.
 Can be 'Verbose' (default), 'Warning' or 'Error'.
 
@@ -100,7 +84,6 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -117,7 +100,6 @@ Accept wildcard characters: False
 ```
 
 ### -Confirm
-
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -133,17 +115,17 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### [string]
-
 ## OUTPUTS
 
 ### -
+## NOTES
 
 ## RELATED LINKS
 
 [https://github.com/philmph/Log-istic/blob/main/docs/Write-Logentry.md](https://github.com/philmph/Log-istic/blob/main/docs/Write-Logentry.md)
+

--- a/src/Logistic/classes/Logistic.ps1
+++ b/src/Logistic/classes/Logistic.ps1
@@ -4,6 +4,7 @@ class Logistic {
     [LogisticType]$Type
     [LogisticFormat]$Format
 
+    hidden [string]$LogID
     hidden [System.IO.StreamWriter]$StreamWriter
 
     # Hidden init methods
@@ -27,10 +28,13 @@ class Logistic {
             throw "$Path is not valid"
         }
 
+        $GUID = [guid]::NewGuid().Guid
+
         $this.Path     = $Path
         $this.Fullpath = $Fullname
         $this.Type     = $Type
         $this.Format   = $Format
+        $this.LogID    = $GUID
 
         if ($Type -eq [LogisticType]::StreamWriter) {
             $this.InitializeStreamWriter()

--- a/src/Logistic/functions/private/GetLogentry.ps1
+++ b/src/Logistic/functions/private/GetLogentry.ps1
@@ -3,6 +3,8 @@ function GetLogentry {
 
     # Data is verified in public funtions
     param (
+        [string]$LogID,
+
         [Parameter(Mandatory)]
         [string]$Format,
 
@@ -29,6 +31,7 @@ function GetLogentry {
     switch ($Format) {
         'JSON' {
             $Output = [PSCustomObject] @{
+                LogID     = $LogID
                 Timestamp = $Timestamp.ToString('yyyy-MM-dd\ HH\:mm\:ss\.fff')
                 Callstack = $CallstackOutput -as [string]
                 Data      = $InputObject

--- a/src/Logistic/functions/public/ConvertTo-Logentry.ps1
+++ b/src/Logistic/functions/public/ConvertTo-Logentry.ps1
@@ -15,13 +15,18 @@ function ConvertTo-Logentry {
     .PARAMETER Type
         Defines the log type. Can be 'Verbose' (default), 'Warning' or 'Error'.
 
-    .EXAMPLE
-        ConvertTo-Logentry -InputObject "Teststring" -Format JSON
-        {"Timestamp":"2021-08-01 23:09:11.179","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
+    .PARAMETER LogID
+        Optional to define a LogID to easier reference log entires later.
 
     .EXAMPLE
-        ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON
-        {"Timestamp":"2021-08-01 23:09:58.362","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
+        ConvertTo-Logentry -InputObject "Teststring" -Format JSON
+        {"LogID":"","Timestamp":"2021-08-11 22:30:33.130","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
+
+    .EXAMPLE
+        ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON -LogID 1234
+        {"LogID":1234,"Timestamp":"2021-08-11 22:30:45.221","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
+
+        Using -LogID to add an unique identifier to the logentry.
 
     .EXAMPLE
         ConvertTo-Logentry -InputObject "Teststring" -Format SCCM

--- a/src/Logistic/functions/public/ConvertTo-Logentry.ps1
+++ b/src/Logistic/functions/public/ConvertTo-Logentry.ps1
@@ -64,7 +64,9 @@ function ConvertTo-Logentry {
 
         [Parameter()]
         [ValidateSet('Verbose', 'Warning', 'Error')]
-        [string]$Type = 'Verbose'
+        [string]$Type = 'Verbose',
+
+        [string]$LogID = ''
     )
 
     begin {
@@ -79,6 +81,7 @@ function ConvertTo-Logentry {
         $Callstack = $MyInvocation
 
         $GetLogEntryArgs = @{
+            LogID       = $LogID
             Format      = $Format
             Timestamp   = $Timestamp
             Callstack   = $Callstack

--- a/src/Logistic/functions/public/ConvertTo-Logentry.ps1
+++ b/src/Logistic/functions/public/ConvertTo-Logentry.ps1
@@ -16,19 +16,19 @@ function ConvertTo-Logentry {
         Defines the log type. Can be 'Verbose' (default), 'Warning' or 'Error'.
 
     .EXAMPLE
-        C:\> ConvertTo-Logentry -InputObject "Teststring" -Format JSON
+        ConvertTo-Logentry -InputObject "Teststring" -Format JSON
         {"Timestamp":"2021-08-01 23:09:11.179","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 
     .EXAMPLE
-        C:\> ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON
+        ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format JSON
         {"Timestamp":"2021-08-01 23:09:58.362","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Verbose"}
 
     .EXAMPLE
-        C:\> ConvertTo-Logentry -InputObject "Teststring" -Format SCCM
+        ConvertTo-Logentry -InputObject "Teststring" -Format SCCM
         <![LOG[Teststring]LOG]!><time="23:10:55.309843" date="2021-08-01" component="Runspace" context="" type="1" thread="" file="Runspace">
 
     .EXAMPLE
-        C:\> ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format SCCM
+        ConvertTo-Logentry -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Format SCCM
         <![LOG[@{Testobject=Data}]LOG]!><time="23:11:19.298018" date="2021-08-01" component="Runspace" context="" type="1" thread="" file="Runspace">
 
     .INPUTS
@@ -36,10 +36,6 @@ function ConvertTo-Logentry {
 
     .OUTPUTS
         [string]
-
-    .NOTES
-        Author: Philipp Maier
-        Author Git: https://github.com/philmph
 
     .LINK
         https://github.com/philmph/Log-istic/blob/main/docs/ConvertTo-Logentry.md

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -70,6 +70,13 @@ function Get-LogisticLog {
             })]
         [string]$Path,
 
+        [Parameter()]
+        [string]$LogID = 'All',
+
+        [Parameter()]
+        [ValidateSet('All', 'Verbose', 'Warning', 'Error')]
+        [string]$Type = 'All',
+
         [int16]$JSONDepth = 3
     )
 
@@ -98,9 +105,9 @@ function Get-LogisticLog {
 
                     $Output = $Line |
                     ConvertFrom-Json |
+                    # LogID filter only works for JSON objects
+                    Where-Object -FilterScript { ($LogID -eq 'All') -or ($LogID -eq $_.LogID) }
                     Select-Object -Property *, @{ N = 'TimestampDatetime'; E = { $_.Timestamp -as [Datetime] } }
-
-                    Write-Output $Output
                 }
 
                 'SCCM' {
@@ -123,9 +130,11 @@ function Get-LogisticLog {
                         Type              = $TypeLong
                         TimestampDatetime = $Timestamp -as [Datetime]
                     }
-
-                    Write-Output $Output
                 }
+            }
+
+            if (($Type -eq 'All') -or ($Type -eq $Output.Type)) {
+                Write-Output -InputObject $Output
             }
         }
     }

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -13,7 +13,7 @@ function Get-LogisticLog {
         Defines the object depth (only relevant for JSON logfiles).
 
     .EXAMPLE
-        C:\> Get-LogisticLog -Path .\logistic_json.log
+        Get-LogisticLog -Path .\logistic_json.log
 
         Timestamp         : 2021-08-02 09:49:33.007
         Callstack         : Runspace
@@ -22,11 +22,11 @@ function Get-LogisticLog {
         TimestampDatetime : 02.08.2021 09:49:33
 
         # Content of logistic_json.log
-        C:\> Get-Content .\logistic_json.log
+        Get-Content .\logistic_json.log
         {"Timestamp":"2021-08-02 09:49:33.007","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
 
     .EXAMPLE
-        C:\Users\maierp\Documents\git\nogit> Get-LogisticLog -Path .\logistic_sccm.log
+        Get-LogisticLog -Path .\logistic_sccm.log
 
         Timestamp         : 2021-08-02 09:49:45.330436
         Callstack         : Runspace
@@ -35,7 +35,7 @@ function Get-LogisticLog {
         TimestampDatetime : 02.08.2021 09:49:45
 
         # Content of logistic_sccm.log
-        C:\> Get-Content .\logistic_sccm.log
+        Get-Content .\logistic_sccm.log
         <![LOG[Teststring]LOG]!><time="09:49:45.330436" date="2021-08-02" component="Runspace" context="" type="1" thread="" file="Runspace">
 
     .INPUTS
@@ -43,10 +43,6 @@ function Get-LogisticLog {
 
     .OUTPUTS
         [psobject]
-
-    .NOTES
-        Author: Philipp Maier
-        Author Git: https://github.com/philmph
 
     .LINK
         https://github.com/philmph/Log-istic/blob/main/docs/Get-LogisticLog.md

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -82,6 +82,13 @@ function Get-LogisticLog {
 
     begin {
         Set-StrictMode -Version 3
+
+        # Only use $JSONDepth when PSVersion >5
+        if ($PSVersionTable.PSVersion.Major -gt 5) {
+            $PSDefaultParameterValues = @{
+                'ConvertFrom-Json:Depth' = $JSONDepth
+            }
+        }
     }
 
     process {
@@ -96,13 +103,6 @@ function Get-LogisticLog {
         foreach ($Line in $Content) {
             switch ($Type) {
                 'JSON' {
-                    # Only use $JSONDepth when PSVersion >5
-                    if ($PSVersionTable.PSVersion.Major -gt 5) {
-                        $PSDefaultParameterValues = @{
-                            'ConvertFrom-Json:Depth' = $JSONDepth
-                        }
-                    }
-
                     $Output = $Line |
                     ConvertFrom-Json |
                     # LogID filter only works for JSON objects

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -7,18 +7,36 @@ function Get-LogisticLog {
         Retrieves Logistic logfile data and converts them into PowerShell objects.
 
     .PARAMETER Path
-        Defines the path to the logfile.
+        Defines the path to the logfile. Possible values 'All' (default) or a GUID.
+
+    .PARAMETER LogID
+        Defines the LogID to filter the log. Possible values 'All' (default), 'Verbose', 'Warning' and 'Error'.
+
+    .PARAMETER Type
+        Defines the Type of entry to filter the log.
 
     .PARAMETER JSONDepth
-        Defines the object depth (only relevant for JSON logfiles).
+        Defines the object depth (only relevant for JSON logfiles). Only used in major PowerShell version >= 5.
 
     .EXAMPLE
         Get-LogisticLog -Path .\logistic_json.log
+        LogID             : 6200096f-1311-45ba-a67c-22b8710152f2
         Timestamp         : 2021-08-02 09:49:33.007
         Callstack         : Runspace
         Data              : Teststring
         Type              : Verbose
         TimestampDatetime : 02.08.2021 09:49:33
+
+    .EXAMPLE
+        Get-LogisticLog -Path .\logistic_json.log -LogID '4c7cd194-7059-4f36-822d-3b4722b7cdc8'
+        LogID             : 4c7cd194-7059-4f36-822d-3b4722b7cdc8
+        Timestamp         : 2021-08-11 22:28:13.961
+        Callstack         : Runspace
+        Data              : Teststring
+        Type              : Error
+        TimestampDatetime : 11.08.2021 22:28:13
+
+        Using -LogID to filter for '4c7cd194-7059-4f36-822d-3b4722b7cdc8'. Alternatively you can filter for -Type.
 
     .EXAMPLE
         Get-LogisticLog -Path .\logistic_sccm.log
@@ -27,6 +45,8 @@ function Get-LogisticLog {
         Data              : Teststring
         Type              : Verbose
         TimestampDatetime : 02.08.2021 09:49:45
+
+        Note that SCCM doesn't provide the LogID functionality.
 
     .INPUTS
         [string]
@@ -92,7 +112,7 @@ function Get-LogisticLog {
                     $Output = $Line |
                     ConvertFrom-Json |
                     # LogID filter only works for JSON objects
-                    Where-Object -FilterScript { ($LogID -eq 'All') -or ($LogID -eq $_.LogID) }
+                    Where-Object -FilterScript { ($LogID -eq 'All') -or ($LogID -eq $_.LogID) } |
                     Select-Object -Property *, @{ N = 'TimestampDatetime'; E = { $_.Timestamp -as [Datetime] } }
                 }
 

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -89,8 +89,15 @@ function Get-LogisticLog {
         foreach ($Line in $Content) {
             switch ($Type) {
                 'JSON' {
+                    # Only use $JSONDepth when PSVersion >5
+                    if ($PSVersionTable.PSVersion.Major -gt 5) {
+                        $PSDefaultParameterValues = @{
+                            'ConvertFrom-Json:Depth' = $JSONDepth
+                        }
+                    }
+
                     $Output = $Line |
-                    ConvertFrom-Json -Depth $JSONDepth |
+                    ConvertFrom-Json |
                     Select-Object -Property *, @{ N = 'TimestampDatetime'; E = { $_.Timestamp -as [Datetime] } }
 
                     Write-Output $Output

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -14,29 +14,19 @@ function Get-LogisticLog {
 
     .EXAMPLE
         Get-LogisticLog -Path .\logistic_json.log
-
         Timestamp         : 2021-08-02 09:49:33.007
         Callstack         : Runspace
         Data              : Teststring
         Type              : Verbose
         TimestampDatetime : 02.08.2021 09:49:33
 
-        # Content of logistic_json.log
-        Get-Content .\logistic_json.log
-        {"Timestamp":"2021-08-02 09:49:33.007","Callstack":"Runspace","Data":"Teststring","Type":"Verbose"}
-
     .EXAMPLE
         Get-LogisticLog -Path .\logistic_sccm.log
-
         Timestamp         : 2021-08-02 09:49:45.330436
         Callstack         : Runspace
         Data              : Teststring
         Type              : Verbose
         TimestampDatetime : 02.08.2021 09:49:45
-
-        # Content of logistic_sccm.log
-        Get-Content .\logistic_sccm.log
-        <![LOG[Teststring]LOG]!><time="09:49:45.330436" date="2021-08-02" component="Runspace" context="" type="1" thread="" file="Runspace">
 
     .INPUTS
         [string]

--- a/src/Logistic/functions/public/Get-LogisticLog.ps1
+++ b/src/Logistic/functions/public/Get-LogisticLog.ps1
@@ -80,14 +80,14 @@ function Get-LogisticLog {
     process {
         $Content = @(Get-Content -Path $Path -Encoding utf8)
 
-        $Type = switch -Regex ($Content[0]) {
+        $ContentType = switch -Regex ($Content[0]) {
             '^\{"' { 'JSON' }
             '^<!' { 'SCCM' }
             default { Write-Error -Message 'Cannot validate log format' -ErrorAction 'Stop' }
         }
 
         foreach ($Line in $Content) {
-            switch ($Type) {
+            switch ($ContentType) {
                 'JSON' {
                     $Output = $Line |
                     ConvertFrom-Json |

--- a/src/Logistic/functions/public/Write-Logentry.ps1
+++ b/src/Logistic/functions/public/Write-Logentry.ps1
@@ -16,21 +16,21 @@ function Write-Logentry {
         Defines the log type. Can be 'Verbose' (default), 'Warning' or 'Error'.
 
     .EXAMPLE
-        C:\> Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
+        Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
 
         WARNING: Teststring
 
         # Content of logistic.log
-        C:\> Get-Content .\logistic.log
+        Get-Content .\logistic.log
         {"Timestamp":"2021-08-02 20:37:59.548","Callstack":"Runspace","Data":"Teststring","Type":"Warning"}
 
     .EXAMPLE
-        C:\> Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
+        Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
 
         Write-Logentry : @{Testobject=Data}
 
         # Content of logistic.log
-        C:\> Get-Content .\logistic.log
+        Get-Content .\logistic.log
         {"Timestamp":"2021-08-02 20:39:57.247","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Error"}
 
     .INPUTS
@@ -38,10 +38,6 @@ function Write-Logentry {
 
     .OUTPUTS
         -
-
-    .NOTES
-        Author: Philipp Maier
-        Author Git: https://github.com/philmph
 
     .LINK
         https://github.com/philmph/Log-istic/blob/main/docs/Write-Logentry.md

--- a/src/Logistic/functions/public/Write-Logentry.ps1
+++ b/src/Logistic/functions/public/Write-Logentry.ps1
@@ -89,6 +89,7 @@ function Write-Logentry {
         $Callstack = $MyInvocation
 
         $GetLogEntryArgs = @{
+            LogID       = $LogisticObject.LogID
             Format      = $LogisticObject.Format
             Timestamp   = $Timestamp
             Callstack   = $Callstack

--- a/src/Logistic/functions/public/Write-Logentry.ps1
+++ b/src/Logistic/functions/public/Write-Logentry.ps1
@@ -16,12 +16,19 @@ function Write-Logentry {
         Defines the log type. Can be 'Verbose' (default), 'Warning' or 'Error'.
 
     .EXAMPLE
-        Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
+        Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring1'
+
+    .EXAMPLE
+        Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring2' -Type Warning
         WARNING: Teststring
+
+        This example outputs a WARNING message to the console on default $WarningPreference
 
     .EXAMPLE
         Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
         Write-Logentry : @{Testobject=Data}
+
+        This example outputs an ERROR message to the console on default $ErrorPreference
 
     .INPUTS
         [string]

--- a/src/Logistic/functions/public/Write-Logentry.ps1
+++ b/src/Logistic/functions/public/Write-Logentry.ps1
@@ -17,21 +17,11 @@ function Write-Logentry {
 
     .EXAMPLE
         Write-Logentry -LogisticObject $Logistic -InputObject 'Teststring' -Type Warning
-
         WARNING: Teststring
-
-        # Content of logistic.log
-        Get-Content .\logistic.log
-        {"Timestamp":"2021-08-02 20:37:59.548","Callstack":"Runspace","Data":"Teststring","Type":"Warning"}
 
     .EXAMPLE
         Write-Logentry -LogisticObject $Logistic -InputObject ([PSCustomObject]@{Testobject = 'Data'}) -Type Error
-
         Write-Logentry : @{Testobject=Data}
-
-        # Content of logistic.log
-        Get-Content .\logistic.log
-        {"Timestamp":"2021-08-02 20:39:57.247","Callstack":"Runspace","Data":{"Testobject":"Data"},"Type":"Error"}
 
     .INPUTS
         [string]


### PR DESCRIPTION
### Added

- GUID as `LogID` for easier tracing of logentries which belong together
- `LogID` and `Type` filter for `Get-LogisticLog`
- Optional Parameter `LogID` for `ConvertTo-Logentry`

### Fixed

- `Get-LogisticLog` for PowerShell version 5 missing parameter `-Depth` for `ConvertFrom-Json`